### PR TITLE
Add The One Probe Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,11 +129,15 @@ task setup {
 repositories {
     mavenCentral()
     maven { url = "http://dvs1.progwml6.com/files/maven" }
+    maven { url = "http://maven.tterrag.com/" }
+    maven { url = "http://maven.covers1624.net" }
 }
 
 dependencies {
     compile "mezz.jei:jei_${project.mc_version}:$jei_version:api"
     runtime "mezz.jei:jei_${project.mc_version}:$jei_version"
+    deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.19-11"
+    deobfCompile "cofh:RedstoneFlux:1.12-2.0.0.1:universal"
 }
 
 processResources {

--- a/src/main/java/wiresegal/hover/Hoverboard.java
+++ b/src/main/java/wiresegal/hover/Hoverboard.java
@@ -10,14 +10,19 @@ import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.EntityEntry;
 import net.minecraftforge.fml.common.registry.EntityEntryBuilder;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import wiresegal.hover.compat.TOPCompatibility;
 import wiresegal.hover.core.CommonProxy;
 import wiresegal.hover.entity.EntityHoverboard;
 import wiresegal.hover.entity.render.MovingSoundHoverboard;
@@ -44,7 +49,7 @@ public class Hoverboard {
     public static ItemHoverboard CREATIVE;
 
     public static SoundEvent WHIRR;
-
+    
     @SubscribeEvent
     public static void onRegisterItems(RegistryEvent.Register<Item> event) {
         event.getRegistry().register(HOVERBOARD = new ItemHoverboard("hoverboard"));
@@ -79,6 +84,12 @@ public class Hoverboard {
     @SideOnly(Side.CLIENT)
     public void onClientInit(FMLPreInitializationEvent event) {
         RenderingRegistry.registerEntityRenderingHandler(EntityHoverboard.class, RenderHoverboard::new);
+    }
+    
+    @Mod.EventHandler
+    public void onInit(FMLInitializationEvent event) {
+        if(Loader.isModLoaded("theoneprobe"))
+            FMLInterModComms.sendFunctionMessage("theoneprobe","getTheOneProbe","wiresegal.hover.compat.TOPCompatibility");
     }
 
     @SubscribeEvent

--- a/src/main/java/wiresegal/hover/compat/TOPCompatibility.java
+++ b/src/main/java/wiresegal/hover/compat/TOPCompatibility.java
@@ -13,6 +13,7 @@ import mcjty.theoneprobe.config.Config;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
@@ -39,13 +40,19 @@ public class TOPCompatibility implements Function<ITheOneProbe, Void> {
 					if(entity instanceof EntityHoverboard) {
 						int currentPower = ((EntityHoverboard)entity).getPower();
 						int maxPower = ((EntityHoverboard)entity).getMaxFuel();
+						boolean creative = ((EntityHoverboard)entity).isCreative();
 						
-						iProbeInfo.progress(currentPower,maxPower,iProbeInfo.defaultProgressStyle()
-								.suffix("FE")
-								.filledColor(Config.rfbarFilledColor)
-								.alternateFilledColor(Config.rfbarAlternateFilledColor)
-								.borderColor(Config.rfbarBorderColor)
-								.numberFormat(Config.rfFormat));
+						if(!creative) {
+							iProbeInfo.progress(currentPower, maxPower, iProbeInfo
+									.defaultProgressStyle()
+									.suffix("FE")
+									.filledColor(Config.rfbarFilledColor)
+									.alternateFilledColor(Config.rfbarAlternateFilledColor)
+									.borderColor(Config.rfbarBorderColor)
+									.numberFormat(Config.rfFormat));
+						} else {
+							iProbeInfo.text(TextFormatting.LIGHT_PURPLE + "Creative");
+						}
 					}
 				}
 				

--- a/src/main/java/wiresegal/hover/compat/TOPCompatibility.java
+++ b/src/main/java/wiresegal/hover/compat/TOPCompatibility.java
@@ -1,0 +1,57 @@
+package wiresegal.hover.compat;
+
+import com.google.common.base.Function;
+import mcjty.theoneprobe.api.IProbeHitEntityData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.IProbeInfoEntityProvider;
+import mcjty.theoneprobe.api.IProgressStyle;
+import mcjty.theoneprobe.api.ITheOneProbe;
+import mcjty.theoneprobe.api.ProbeMode;
+import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
+import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
+import mcjty.theoneprobe.config.Config;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+import wiresegal.hover.Hoverboard;
+import wiresegal.hover.entity.EntityHoverboard;
+import wiresegal.hover.item.ItemHoverboard;
+
+import javax.annotation.Nullable;
+
+
+public class TOPCompatibility implements Function<ITheOneProbe, Void> {
+
+		@Nullable
+		@Override
+		public Void apply(ITheOneProbe theOneProbe) {
+			theOneProbe.registerEntityProvider(new IProbeInfoEntityProvider() {
+				@Override
+				public String getID() {
+					return Hoverboard.MOD_ID+":default";
+				}
+				
+				@Override
+				public void addProbeEntityInfo(ProbeMode probeMode, IProbeInfo iProbeInfo, EntityPlayer entityPlayer, World world, Entity entity, IProbeHitEntityData iProbeHitEntityData) {
+					if(entity instanceof EntityHoverboard) {
+						int currentPower = ((EntityHoverboard)entity).getPower();
+						int maxPower = ((EntityHoverboard)entity).getMaxFuel();
+						
+						iProbeInfo.progress(currentPower,maxPower,iProbeInfo.defaultProgressStyle()
+								.suffix("FE")
+								.filledColor(Config.rfbarFilledColor)
+								.alternateFilledColor(Config.rfbarAlternateFilledColor)
+								.borderColor(Config.rfbarBorderColor)
+								.numberFormat(Config.rfFormat));
+					}
+				}
+				
+				
+			});
+			
+			return null;
+	}
+}

--- a/src/main/resources/assets/hoverboard/lang/en_us.lang
+++ b/src/main/resources/assets/hoverboard/lang/en_us.lang
@@ -1,3 +1,4 @@
 item.hoverboard.hoverboard.name=Hoverboard
 item.hoverboard.creative_hoverboard.name=Creative Hoverboard
 hoverboard.whirr=Hoverboard whirrs
+entity.hoverboard.name=Hoverboard


### PR DESCRIPTION
This PR adds The One Probe Support for the Hoverboard Entity.

When looking at the hoverboard, the probe displays the entities current FE or if the board is creative
This also adds in the proper localization for the hoverboard for en_us.lag

![probeexample](https://user-images.githubusercontent.com/5694243/40484428-9aca4100-5f29-11e8-8c9a-ddaace263d7c.png)

